### PR TITLE
Add get Ethereum network name

### DIFF
--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import eth_abi
 import requests
+from enum import Enum
 from eth_abi.exceptions import InsufficientDataBytes
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
@@ -25,6 +26,24 @@ logger = getLogger(__name__)
 
 
 EthereumHash = Union[bytes, str]
+
+
+class EthereumNetworkName(Enum):
+    UNKNOWN = -1
+    OLYMPIC = 0
+    MAINNET = 1
+    ROPSTEN = 3
+    RINKEBY = 4
+    GOERLI = 5
+    KOVAN = 42
+    default = UNKNOWN
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.UNKNOWN
+
+    def __str__(self):
+        return str(self.value)
 
 
 class EthereumClientException(ValueError):
@@ -633,6 +652,16 @@ class EthereumClient:
                                 request_kwargs={'timeout': timeout})
         else:
             return self.w3_provider
+
+    def get_network_name(self):
+        """
+        Get network name based on the network version id
+        :return: The name of the current Ethereum network
+        """
+        if isinstance(self.w3, Web3):
+            return EthereumNetworkName(self.w3.net.version).name
+        else:
+            return EthereumNetworkName.UNKNOWN.name
 
     def get_nonce_for_account(self, address: str, block_identifier: Optional[str] = 'latest'):
         """

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -653,15 +653,12 @@ class EthereumClient:
         else:
             return self.w3_provider
 
-    def get_network_name(self):
+    def get_network_name(self) -> EthereumNetworkName:
         """
         Get network name based on the network version id
-        :return: The name of the current Ethereum network
+        :return: The EthereumNetworkName enum type
         """
-        if isinstance(self.w3, Web3):
-            return EthereumNetworkName(self.w3.net.version).name
-        else:
-            return EthereumNetworkName.UNKNOWN.name
+        return EthereumNetworkName(self.w3.net.version)
 
     def get_nonce_for_account(self, address: str, block_identifier: Optional[str] = 'latest'):
         """

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -4,7 +4,8 @@ from eth_account import Account
 from hexbytes import HexBytes
 from web3.datastructures import AttributeDict
 
-from ..ethereum_client import (EthereumClientProvider, FromAddressNotFound,
+from ..ethereum_client import (EthereumNetworkName,
+                               EthereumClientProvider, FromAddressNotFound,
                                InsufficientFunds, InvalidERC20Info,
                                InvalidNonce, SenderAccountNotFoundInNode)
 from ..utils import get_eth_address_with_key
@@ -517,6 +518,10 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
 
         nonce = self.ethereum_client.get_nonce_for_account(address, block_identifier='pending')
         self.assertEqual(nonce, 0)
+
+    def test_get_ethereum_network(self):
+        ethereum_network_name = self.ethereum_client.get_network_name()
+        self.assertEqual(ethereum_network_name, EthereumNetworkName.UNKNOWN.name)
 
     def test_estimate_data_gas(self):
         self.assertEqual(self.ethereum_client.estimate_data_gas(HexBytes('')), 0)

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -418,6 +418,14 @@ class TestParityModule(EthereumTestCaseMixin, TestCase):
             self.ethereum_client.parity.trace_filter(from_address=Account.create().address)
 
 
+class TestEthereumNetworkName(EthereumTestCaseMixin, TestCase):
+    def test_default_ethereum_network_name(self):
+        self.assertEqual(EthereumNetworkName(EthereumNetworkName.default), EthereumNetworkName.UNKNOWN)
+
+    def test_default_ethereum_network_name(self):
+        self.assertEqual(EthereumNetworkName(2), EthereumNetworkName.UNKNOWN)
+
+
 class TestEthereumClient(EthereumTestCaseMixin, TestCase):
     def test_current_block_number(self):
         self.assertGreaterEqual(self.ethereum_client.current_block_number, 0)

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -521,7 +521,7 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
 
     def test_get_ethereum_network(self):
         ethereum_network_name = self.ethereum_client.get_network_name()
-        self.assertEqual(ethereum_network_name, EthereumNetworkName.UNKNOWN.name)
+        self.assertEqual(ethereum_network_name, EthereumNetworkName.UNKNOWN)
 
     def test_estimate_data_gas(self):
         self.assertEqual(self.ethereum_client.estimate_data_gas(HexBytes('')), 0)


### PR DESCRIPTION
  - Add `EthereumNetworkName` enum.
  - Add `get_network_name` method in EthereumClient class.
  - Add `test_get_ethereum_network` test.