### PR TITLE
Fix `get_network_name`

### DIFF
--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -1,10 +1,10 @@
+from enum import Enum
 from functools import wraps
 from logging import getLogger
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 import eth_abi
 import requests
-from enum import Enum
 from eth_abi.exceptions import InsufficientDataBytes
 from eth_account import Account
 from eth_account.signers.local import LocalAccount

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -658,7 +658,7 @@ class EthereumClient:
         Get network name based on the network version id
         :return: The EthereumNetworkName enum type
         """
-        return EthereumNetworkName(self.w3.net.version)
+        return EthereumNetworkName(int(self.w3.net.version))
 
     def get_nonce_for_account(self, address: str, block_identifier: Optional[str] = 'latest'):
         """

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -528,24 +528,24 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
         gas2 = self.ethereum_client.estimate_gas(from_, erc20_contract.address, 0, data, block_identifier='pending')
         self.assertLess(gas2, gas)
 
+    def test_get_ethereum_network_default(self):
+        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.UNKNOWN)
+
+    @mock.patch.object(Net, 'version', return_value='1', new_callable=mock.PropertyMock)
+    def test_mock_get_ethereum_network_mainnet(self, version_mock):
+        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.MAINNET)
+
+    @mock.patch.object(Net, 'version', return_value='4', new_callable=mock.PropertyMock)
+    def test_mock_get_ethereum_network_rinkeby(self, version_mock):
+        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.RINKEBY)
+
     def test_get_nonce(self):
-        address, _ = get_eth_address_with_key()
+        address = Account.create().address
         nonce = self.ethereum_client.get_nonce_for_account(address)
         self.assertEqual(nonce, 0)
 
         nonce = self.ethereum_client.get_nonce_for_account(address, block_identifier='pending')
         self.assertEqual(nonce, 0)
-
-    def test_get_ethereum_default_network(self):
-        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.UNKNOWN)
-
-    @mock.patch.object(Net, 'version', return_value='1', new_callable=mock.PropertyMock)
-    def test_mock_get_ethereum_mainnet_network(self, version_mock):
-        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.MAINNET)
-
-    @mock.patch.object(Net, 'version', return_value='4', new_callable=mock.PropertyMock)
-    def test_mock_get_ethereum_rinkeby_network(self, version_mock):
-        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.RINKEBY)
 
     def test_estimate_data_gas(self):
         self.assertEqual(self.ethereum_client.estimate_data_gas(HexBytes('')), 0)

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -538,9 +538,13 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
     def test_get_ethereum_default_network(self):
         self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.UNKNOWN)
 
-    @mock.patch.object(Net, 'version', return_value="1", autospec=True)
+    @mock.patch.object(Net, 'version', return_value='4', new_callable=mock.PropertyMock)
     def test_mock_get_ethereum_mainnet_network(self, version_mock):
         self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.MAINNET)
+
+    @mock.patch.object(Net, 'version', return_value='4', new_callable=mock.PropertyMock)
+    def test_mock_get_ethereum_rinkeby_network(self, version_mock):
+        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.RINKEBY)
 
     def test_estimate_data_gas(self):
         self.assertEqual(self.ethereum_client.estimate_data_gas(HexBytes('')), 0)

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
+from unittest import mock
 
 from eth_account import Account
 from hexbytes import HexBytes
 from web3.datastructures import AttributeDict
+from web3.net import Net
 
 from ..ethereum_client import (EthereumNetworkName,
                                EthereumClientProvider, FromAddressNotFound,
@@ -425,6 +427,12 @@ class TestEthereumNetworkName(EthereumTestCaseMixin, TestCase):
     def test_default_ethereum_network_name(self):
         self.assertEqual(EthereumNetworkName(2), EthereumNetworkName.UNKNOWN)
 
+    def test_mainnet_ethereum_network_name(self):
+        self.assertEqual(EthereumNetworkName(1), EthereumNetworkName.MAINNET)
+
+    def test_rinkeby_ethereum_network_name(self):
+        self.assertEqual(EthereumNetworkName(4), EthereumNetworkName.RINKEBY)
+
 
 class TestEthereumClient(EthereumTestCaseMixin, TestCase):
     def test_current_block_number(self):
@@ -527,9 +535,12 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
         nonce = self.ethereum_client.get_nonce_for_account(address, block_identifier='pending')
         self.assertEqual(nonce, 0)
 
-    def test_get_ethereum_network(self):
-        ethereum_network_name = self.ethereum_client.get_network_name()
-        self.assertEqual(ethereum_network_name, EthereumNetworkName.UNKNOWN)
+    def test_get_ethereum_default_network(self):
+        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.UNKNOWN)
+
+    @mock.patch.object(Net, 'version', return_value="1", autospec=True)
+    def test_mock_get_ethereum_mainnet_network(self, version_mock):
+        self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.MAINNET)
 
     def test_estimate_data_gas(self):
         self.assertEqual(self.ethereum_client.estimate_data_gas(HexBytes('')), 0)

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -1,15 +1,16 @@
-from django.test import TestCase
 from unittest import mock
+
+from django.test import TestCase
 
 from eth_account import Account
 from hexbytes import HexBytes
 from web3.datastructures import AttributeDict
 from web3.net import Net
 
-from ..ethereum_client import (EthereumNetworkName,
-                               EthereumClientProvider, FromAddressNotFound,
-                               InsufficientFunds, InvalidERC20Info,
-                               InvalidNonce, SenderAccountNotFoundInNode)
+from ..ethereum_client import (EthereumClientProvider, EthereumNetworkName,
+                               FromAddressNotFound, InsufficientFunds,
+                               InvalidERC20Info, InvalidNonce,
+                               SenderAccountNotFoundInNode)
 from ..utils import get_eth_address_with_key
 from .ethereum_test_case import EthereumTestCaseMixin
 

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -538,7 +538,7 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
     def test_get_ethereum_default_network(self):
         self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.UNKNOWN)
 
-    @mock.patch.object(Net, 'version', return_value='4', new_callable=mock.PropertyMock)
+    @mock.patch.object(Net, 'version', return_value='1', new_callable=mock.PropertyMock)
     def test_mock_get_ethereum_mainnet_network(self, version_mock):
         self.assertEqual(self.ethereum_client.get_network_name(), EthereumNetworkName.MAINNET)
 


### PR DESCRIPTION
  - Convert web3 Net.version to int as valid parameter in
EthereumNetworkName enum.
  - Add unittest mock test with version return value equals to 1
(MAINNET).