### PR TITLE
Fixed fetching the default db connection in newer versions of Django.

### DIFF
--- a/gnosis/eth/django/models.py
+++ b/gnosis/eth/django/models.py
@@ -1,4 +1,4 @@
-from django.db import DefaultConnectionProxy, models
+from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 import ethereum.utils
@@ -6,7 +6,12 @@ from hexbytes import HexBytes
 
 from .validators import validate_checksumed_address
 
-connection = DefaultConnectionProxy()
+try:
+    from django.db import DefaultConnectionProxy
+    connection = DefaultConnectionProxy()
+except ImportError:
+    from django.db import connections
+    connection = connections['default']
 
 
 class EthereumAddressField(models.CharField):


### PR DESCRIPTION
Fixed import error when importing DefaultConnectionProxy in newer versions of Django as this has been replaced and is noted in the Django codebase as can be seen in the link below.

https://github.com/django/django/blob/06fd4df41afb5aa1d681b853c3c08d8c688ca3a5/django/db/__init__.py#L21