### PR TITLE
Fix web3 version range definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "py-eth-sig-utils>=0.3.0",
     "typing-extensions==3.10.0.0; python_version < '3.8'",
     "requests>=2",
-    "web3>=5.18<=5.19",
+    "web3 >=5.18, <=5.19",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "py-eth-sig-utils>=0.3.0",
     "typing-extensions==3.10.0.0; python_version < '3.8'",
     "requests>=2",
-    "web3 >=5.18, <=5.19",
+    "web3 >=5.18,<=5.19",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "py-eth-sig-utils>=0.3.0",
     "typing-extensions==3.10.0.0; python_version < '3.8'",
     "requests>=2",
-    "web3 >=5.18,<=5.19",
+    "web3>=5.18,<=5.19",
 ]
 
 extras_require = {


### PR DESCRIPTION
- The `web3` version range is incorrectly set so when pip downloads the dependencies it actually downloads the latest available version (which has breaking API changes)
- The version should be set according to: https://www.python.org/dev/peps/pep-0508/#grammar 