### PR TITLE
Bump web3 version to 5.23.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "py-eth-sig-utils>=0.3.0",
     "typing-extensions==3.10.0.0; python_version < '3.8'",
     "requests>=2",
-    "web3>=5.18,<=5.19",
+    "web3==5.23.0",
 ]
 
 extras_require = {


### PR DESCRIPTION
- Set `web3` to version `5.23.0` as a requirement.
- Current dependents on this library that update to version `3.2.0` download an incompatible version of `web3`