### PR TITLE
Fix multicall issues

### DIFF
--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -299,9 +299,8 @@ class BatchCallManager(EthereumClientManager):
                     else:
                         return_values.append(normalized_data)
                 except (DecodingError, OverflowError):
-                    # Don't consider DecodingError an error. Only reverts
-                    # fn_name = payload.get('fn_name', HexBytes(payload['data']).hex())
-                    # errors.append(f'`{fn_name}`: DecodingError, cannot decode')
+                    fn_name = payload.get('fn_name', HexBytes(payload['data']).hex())
+                    errors.append(f'`{fn_name}`: DecodingError, cannot decode')
                     return_values.append(None)
 
         if errors and raise_exception:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
 
 setup(
     name='gnosis-py',
-    version='3.3.0',
+    version='3.3.1',
     packages=find_packages(),
     package_data={'gnosis': ['py.typed']},
     install_requires=requirements,


### PR DESCRIPTION
Previously, when a value from a `batch_call` could not be decoded a error was raised. When multicall was implemented it was refactored to return the raw bytes. Some parts of the tx service depends on this logic, so if `raise_exeception=True` a exception will be raised if there's a decoding error or an empty response during `multicall`