### PR TITLE
Fix multicall balances issue

### DIFF
--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -453,7 +453,7 @@ class Erc20Manager(EthereumClientManager):
 
         return_balances = [{
             'token_address': token_address,
-            'balance': 0 if balance is None else balance,
+            'balance': balance if isinstance(balance, int) else 0,  # A `revert` with bytes can be returned
         } for token_address, balance in zip(token_addresses, balances)]
 
         # Add ether balance response
@@ -724,7 +724,7 @@ class Erc721Manager(EthereumClientManager):
             token_addresses,
             raise_exception=False
         )
-        return [TokenBalance(token_address, 0 if balance is None else balance)
+        return [TokenBalance(token_address, balance if isinstance(balance, int) else 0)
                 for (token_address, balance) in zip(token_addresses, balances)]
 
     def get_info(self, token_address: str) -> Erc721Info:

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -11,10 +11,11 @@ from web3.net import Net
 
 from ..constants import GAS_CALL_DATA_BYTE, NULL_ADDRESS
 from ..contracts import get_erc20_contract
-from ..ethereum_client import (BatchCallException, EthereumClient,
-                               EthereumClientProvider, EthereumNetwork,
-                               FromAddressNotFound, InsufficientFunds,
-                               InvalidERC20Info, InvalidNonce, ParityManager,
+from ..ethereum_client import (BatchCallException, Erc20Manager,
+                               EthereumClient, EthereumClientProvider,
+                               EthereumNetwork, FromAddressNotFound,
+                               InsufficientFunds, InvalidERC20Info,
+                               InvalidNonce, ParityManager,
                                SenderAccountNotFoundInNode)
 from ..utils import get_eth_address_with_key
 from .ethereum_test_case import EthereumTestCaseMixin
@@ -235,6 +236,20 @@ class TestERC20Module(EthereumTestCaseMixin, TestCase):
                                {'token_address': erc20.address, 'balance': tokens_value},
                                {'token_address': erc20_2.address, 'balance': tokens_value_2}
                                ])
+
+        with mock.patch.object(EthereumClient, 'batch_call_same_function', return_value=[
+            b'\x08\xc3y\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x17Only the proxy can call\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            5,
+        ]):
+            token_addresses = [
+                '0x57Ab1E02fEE23774580C119740129eAC7081e9D3',
+                '0x6810e776880C02933D47DB1b9fc05908e5386b96'
+            ]
+            self.assertCountEqual(self.ethereum_client.erc20.get_balances(account_address, token_addresses),
+                                  [{'token_address': None, 'balance': value},
+                                   {'token_address': '0x57Ab1E02fEE23774580C119740129eAC7081e9D3', 'balance': 0},
+                                   {'token_address': '0x6810e776880C02933D47DB1b9fc05908e5386b96', 'balance': 5},
+                                   ])
 
     def test_get_total_transfer_history(self):
         amount = 50

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extras_require = {
 
 setup(
     name='gnosis-py',
-    version='3.3.1',
+    version='3.3.2',
     packages=find_packages(),
     package_data={'gnosis': ['py.typed']},
     install_requires=requirements,


### PR DESCRIPTION
- An invalid response was not parsed when a revert calling `balanceOf`
  happened