### PR TITLE
Refactor curve gauges test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
-version: '3.5'
+version: "3.5"
 
 services:
   db:
     image: postgres:10-alpine
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+version: '3.5'
 
 services:
   db:

--- a/gnosis/eth/tests/test_oracles.py
+++ b/gnosis/eth/tests/test_oracles.py
@@ -222,11 +222,8 @@ class TestCurveOracle(EthereumTestCaseMixin, TestCase):
 
         # 3crv gauge deposit: dai, usdc, usdt
         gauge_deposit_address = '0xF5194c3325202F456c95c1Cf0cA36f8475C1949F'
-        lp_token_underlying_tokens = [
-            '0x8e595470Ed749b85C6F7669de83EAe304C2ec68F',
-            '0x76Eb2FE28b36B3ee97F3Adae0C69606eeDB2A37c',
-            '0x48759F220ED983dB51fA7A8C0D2AAb8f3ce4166a'
-        ]
+        gauge_lp_token_address = '0x5282a4eF67D9C33135340fB3289cc1711c13638C'
+        lp_token_underlying_tokens = ['0x8e595470Ed749b85C6F7669de83EAe304C2ec68F', '0x76Eb2FE28b36B3ee97F3Adae0C69606eeDB2A37c', '0x48759F220ED983dB51fA7A8C0D2AAb8f3ce4166a']
 
         underlying_tokens = curve_oracle.get_underlying_tokens(gauge_deposit_address)
         for underlying_token in underlying_tokens:

--- a/gnosis/eth/tests/test_oracles.py
+++ b/gnosis/eth/tests/test_oracles.py
@@ -223,12 +223,10 @@ class TestCurveOracle(EthereumTestCaseMixin, TestCase):
         # 3crv gauge deposit: dai, usdc, usdt
         gauge_deposit_address = '0xF5194c3325202F456c95c1Cf0cA36f8475C1949F'
         gauge_lp_token_address = '0x5282a4eF67D9C33135340fB3289cc1711c13638C'
-        lp_token_underlying_tokens = ['0x8e595470Ed749b85C6F7669de83EAe304C2ec68F', '0x76Eb2FE28b36B3ee97F3Adae0C69606eeDB2A37c', '0x48759F220ED983dB51fA7A8C0D2AAb8f3ce4166a']
+        gauge_underlying_tokens = curve_oracle.get_underlying_tokens(gauge_deposit_address)
+        lp_token_underlying_tokens = curve_oracle.get_underlying_tokens(gauge_lp_token_address)
 
-        underlying_tokens = curve_oracle.get_underlying_tokens(gauge_deposit_address)
-        for underlying_token in underlying_tokens:
-            self.assertIn(underlying_token.address, lp_token_underlying_tokens)
-            self.assertAlmostEqual(underlying_token.quantity, 0.3, delta=0.5)
+        self.assertEqual(gauge_underlying_tokens, lp_token_underlying_tokens)
 
 
 class TestZerionComposedOracle(EthereumTestCaseMixin, TestCase):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
 
 setup(
     name='gnosis-py',
-    version='3.4.2',
+    version='3.4.3',
     packages=find_packages(),
     package_data={'gnosis': ['py.typed']},
     install_requires=requirements,


### PR DESCRIPTION
This PR:
- Refactors curve gauge test so it relies less on hardcoded stuff
- Adds Postgres password env var to the DB container to fix this error:
```
db_1  | Error: Database is uninitialized and superuser password is not specified.
db_1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db_1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db_1  |
db_1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db_1  |        connections without a password. This is *not* recommended.
db_1  |
db_1  |        See PostgreSQL documentation about "trust":
```
