### PR TITLE
feat: expose safe tx eip712 structured data

### DIFF
--- a/gnosis/safe/safe_tx.py
+++ b/gnosis/safe/safe_tx.py
@@ -138,7 +138,7 @@ class SafeTx:
             return self.contract.functions.VERSION().call()
 
     @property
-    def safe_tx_data(self) -> Dict:
+    def eip712_structured_data(self) -> Dict:
         data = self.data.hex() if self.data else ""
 
         # Safes >= 1.0.0 Renamed `baseGas` to `dataGas`
@@ -193,7 +193,7 @@ class SafeTx:
 
     @property
     def safe_tx_hash(self) -> HexBytes:
-        return HexBytes(encode_typed_data(self.safe_tx_data))
+        return HexBytes(encode_typed_data(self.eip712_structured_data))
 
     @property
     def signers(self) -> List[str]:

--- a/gnosis/safe/safe_tx.py
+++ b/gnosis/safe/safe_tx.py
@@ -138,7 +138,7 @@ class SafeTx:
             return self.contract.functions.VERSION().call()
 
     @property
-    def safe_tx_hash(self) -> HexBytes:
+    def safe_tx_data(self) -> Dict:
         data = self.data.hex() if self.data else ""
 
         # Safes >= 1.0.0 Renamed `baseGas` to `dataGas`
@@ -189,7 +189,11 @@ class SafeTx:
             )
             structured_data["domain"]["chainId"] = self.chain_id
 
-        return HexBytes(encode_typed_data(structured_data))
+        return structured_data
+
+    @property
+    def safe_tx_hash(self) -> HexBytes:
+        return HexBytes(encode_typed_data(self.safe_tx_data))
 
     @property
     def signers(self) -> List[str]:


### PR DESCRIPTION
Expose the EIP712 structured data of a SafeTx as `safe_tx_data` (extracted from `safe_tx_hash`).

This structure could be useful elsewhere, ranging from third-party signing to verification purposes.

My use case is passing it to Frame for signing.