### PR TITLE
Port py-eth-sig-utils to eip712-structs

### DIFF
--- a/gnosis/safe/safe_tx.py
+++ b/gnosis/safe/safe_tx.py
@@ -5,12 +5,13 @@ from hexbytes import HexBytes
 from packaging.version import Version
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from web3.types import BlockIdentifier, TxParams, Wei
-
-from py_eth_sig_utils.eip712 import encode_typed_data
+from web3 import Web3
 
 from gnosis.eth import EthereumClient
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.contracts import get_safe_contract
+from eip712_structs import EIP712Struct, Address, Bytes, Uint, make_domain
+from eip712_structs.struct import StructTuple
 
 from .exceptions import (
     CouldNotFinishInitialization,
@@ -138,62 +139,51 @@ class SafeTx:
             return self.contract.functions.VERSION().call()
 
     @property
-    def eip712_structured_data(self) -> Dict:
+    def _eip712_payload(self) -> StructTuple:
         data = self.data.hex() if self.data else ""
-
-        # Safes >= 1.0.0 Renamed `baseGas` to `dataGas`
         safe_version = Version(self.safe_version)
-        base_gas_name = "baseGas" if safe_version >= Version("1.0.0") else "dataGas"
+        assert safe_version >= Version("1.0.0"), f"Unsupported Safe version: {safe_version}"
+        
+        class SafeTx(EIP712Struct):
+            to = Address()
+            value = Uint(256)
+            data = Bytes()
+            operation = Uint(8)
+            safeTxGas = Uint(256)
+            baseGas = Uint(256)
+            gasPrice = Uint(256)
+            gasToken = Address()
+            refundReceiver = Address()
+            nonce = Uint(256)
 
-        structured_data = {
-            "types": {
-                "EIP712Domain": [
-                    {"name": "verifyingContract", "type": "address"},
-                ],
-                "SafeTx": [
-                    {"name": "to", "type": "address"},
-                    {"name": "value", "type": "uint256"},
-                    {"name": "data", "type": "bytes"},
-                    {"name": "operation", "type": "uint8"},
-                    {"name": "safeTxGas", "type": "uint256"},
-                    {"name": base_gas_name, "type": "uint256"},
-                    {"name": "gasPrice", "type": "uint256"},
-                    {"name": "gasToken", "type": "address"},
-                    {"name": "refundReceiver", "type": "address"},
-                    {"name": "nonce", "type": "uint256"},
-                ],
-            },
-            "primaryType": "SafeTx",
-            "domain": {
-                "verifyingContract": self.safe_address,
-            },
-            "message": {
-                "to": self.to,
-                "value": self.value,
-                "data": data,
-                "operation": self.operation,
-                "safeTxGas": self.safe_tx_gas,
-                base_gas_name: self.base_gas,
-                "gasPrice": self.gas_price,
-                "gasToken": self.gas_token,
-                "refundReceiver": self.refund_receiver,
-                "nonce": self.safe_nonce,
-            },
-        }
+        message = SafeTx(
+            to=self.to,
+            value=self.value,
+            data=data,
+            operation=self.operation,
+            safeTxGas=self.safe_tx_gas,
+            baseGas=self.base_gas,
+            gasPrice=self.gas_price,
+            gasToken=self.gas_token,
+            refundReceiver=self.refund_receiver,
+            nonce=self.safe_nonce
+        )
+        domain = make_domain(
+            verifyingContract=self.safe_address,
+            chainId=self.chain_id if safe_version >= Version("1.3.0") else None,
+        )
+        return StructTuple(message, domain)
 
-        # Safes >= 1.3.0 Added `chainId` to the domain
-        if safe_version >= Version("1.3.0"):
-            # EIP712Domain(uint256 chainId,address verifyingContract)
-            structured_data["types"]["EIP712Domain"].insert(
-                0, {"name": "chainId", "type": "uint256"}
-            )
-            structured_data["domain"]["chainId"] = self.chain_id
-
-        return structured_data
+    @property
+    def eip712_structured_data(self) -> Dict:
+        message, domain = self._eip712_payload
+        return message.to_message(domain)
 
     @property
     def safe_tx_hash(self) -> HexBytes:
-        return HexBytes(encode_typed_data(self.eip712_structured_data))
+        message, domain = self._eip712_payload
+        signable_bytes = message.signable_bytes(domain)
+        return HexBytes(Web3.keccak(signable_bytes))
 
     @property
     def signers(self) -> List[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ ethereum==2.3.2
 hexbytes==0.2.2
 packaging
 psycopg2-binary==2.9.1
-py-eth-sig-utils==0.4.0
 requests==2.26.0
 typing-extensions==3.10.0.2
 web3==5.24.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ requirements = [
     "ethereum>=2.3.2",
     "eip712_structs",
     "packaging",
-    "py-eth-sig-utils>=0.3.0",
     "typing-extensions>=3.10; python_version < '3.8'",
     "requests>=2",
     "web3>=5.23.0",


### PR DESCRIPTION
Followed @Uxio0 suggestion from here https://github.com/gnosis/gnosis-py/pull/120#pullrequestreview-796306506

Rewrote EIP712 code of SafeTx to match the library used in Protocol. Removed `py-eth-sig-utils` dependency.