### PR TITLE
Add basic support for EIP1159

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -52,9 +52,8 @@ jobs:
       run: pip install -e .
     - name: Send results to coveralls
       if: ${{ env.COVERALLS_REPO_TOKEN }}
-      run: coveralls
+      run: coveralls --service=github
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for coveralls
   publish:
     runs-on: ubuntu-latest

--- a/gnosis/eth/__init__.py
+++ b/gnosis/eth/__init__.py
@@ -5,12 +5,9 @@ from .ethereum_client import (
     FromAddressNotFound,
     GasLimitExceeded,
     InsufficientFunds,
-    InvalidERC20Info,
-    InvalidERC721Info,
     InvalidNonce,
     NonceTooHigh,
     NonceTooLow,
-    ParityTraceDecodeException,
     ReplacementTransactionUnderpriced,
     SenderAccountNotFoundInNode,
     TransactionAlreadyImported,
@@ -18,3 +15,4 @@ from .ethereum_client import (
     UnknownAccount,
 )
 from .ethereum_network import EthereumNetwork, EthereumNetworkNotSupported
+from .exceptions import InvalidERC20Info, InvalidERC721Info, ParityTraceDecodeException

--- a/gnosis/eth/exceptions.py
+++ b/gnosis/eth/exceptions.py
@@ -1,0 +1,70 @@
+class EthereumClientException(ValueError):
+    pass
+
+
+class TransactionAlreadyImported(EthereumClientException):
+    pass
+
+
+class ReplacementTransactionUnderpriced(EthereumClientException):
+    pass
+
+
+class TransactionQueueLimitReached(EthereumClientException):
+    pass
+
+
+class FromAddressNotFound(EthereumClientException):
+    pass
+
+
+class InvalidNonce(EthereumClientException):
+    pass
+
+
+class NonceTooLow(InvalidNonce):
+    pass
+
+
+class NonceTooHigh(InvalidNonce):
+    pass
+
+
+class InsufficientFunds(EthereumClientException):
+    pass
+
+
+class SenderAccountNotFoundInNode(EthereumClientException):
+    pass
+
+
+class UnknownAccount(EthereumClientException):
+    pass
+
+
+class GasLimitExceeded(EthereumClientException):
+    pass
+
+
+class TransactionGasPriceTooLow(EthereumClientException):
+    pass
+
+
+class ParityTraceDecodeException(EthereumClientException):
+    pass
+
+
+class InvalidERC20Info(EthereumClientException):
+    pass
+
+
+class InvalidERC721Info(EthereumClientException):
+    pass
+
+
+class BatchCallException(EthereumClientException):
+    pass
+
+
+class BatchCallFunctionFailed(BatchCallException):
+    pass

--- a/gnosis/eth/multicall.py
+++ b/gnosis/eth/multicall.py
@@ -16,7 +16,8 @@ from web3.contract import ContractFunction
 from web3.exceptions import ContractLogicError
 
 from . import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
-from .ethereum_client import BatchCallFunctionFailed, EthereumTxSent
+from .ethereum_client import EthereumTxSent
+from .exceptions import BatchCallFunctionFailed
 from .oracles.abis.makerdao import multicall_v2_abi, multicall_v2_bytecode
 
 logger = logging.getLogger(__name__)

--- a/gnosis/eth/tests/test_multicall.py
+++ b/gnosis/eth/tests/test_multicall.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from .. import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
 from ..constants import NULL_ADDRESS
 from ..contracts import get_erc20_contract
-from ..ethereum_client import BatchCallFunctionFailed
+from ..exceptions import BatchCallFunctionFailed
 from ..multicall import Multicall, MulticallDecodedResult
 from .ethereum_test_case import EthereumTestCaseMixin
 from .utils import just_test_if_mainnet_node


### PR DESCRIPTION
- Add function `estimate_fee_eip1159` to get the `baseFee` and the `priorityFee`
- Create function `set_eip1159_fees` to build an EIP1559 transaction from a legacy transaction
- Move exceptions out of `ethereum_client`