### PR TITLE
Add `chainId` to EIP 1559 txs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,7 +51,6 @@ jobs:
     - name: Test setup.py
       run: pip install -e .
     - name: Send results to coveralls
-      if: ${{ env.COVERALLS_REPO_TOKEN }}
       run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Required for coveralls

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -1504,7 +1504,7 @@ class EthereumClient:
                 gas += GAS_CALL_DATA_BYTE
         return gas
 
-    def estimate_fee_eip1159(
+    def estimate_fee_eip1559(
         self, tx_speed: TxSpeed = TxSpeed.NORMAL
     ) -> Tuple[int, int]:
         """
@@ -1534,17 +1534,20 @@ class EthereumClient:
         max_priority_fee_per_gas = result["reward"][0][0]
         return base_fee_per_gas, max_priority_fee_per_gas
 
-    def set_eip1159_fees(
+    def set_eip1559_fees(
         self, tx: TxParams, tx_speed: TxSpeed = TxSpeed.NORMAL
     ) -> TxParams:
         """
-        :return: TxParams in EIP1159 format
-        :raises: ValueError if EIP1159 not supported
+        :return: TxParams in EIP1559 format
+        :raises: ValueError if EIP1559 not supported
         """
-        base_fee_per_gas, max_priority_fee_per_gas = self.estimate_fee_eip1159(tx_speed)
+        base_fee_per_gas, max_priority_fee_per_gas = self.estimate_fee_eip1559(tx_speed)
         tx = dict(tx)  # Don't modify provided tx
         if "gasPrice" in tx:
             del tx["gasPrice"]
+
+        if "chainId" not in tx:
+            tx["chainId"] = self.get_network().value
 
         tx["maxPriorityFeePerGas"] = max_priority_fee_per_gas
         tx["maxFeePerGas"] = base_fee_per_gas + max_priority_fee_per_gas

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -1457,16 +1457,19 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
             self.assertEqual(len(block["parentHash"]), 32)
             self.assertGreaterEqual(len(block["transactions"]), 0)
 
-    def test_set_eip1159_fees(self):
+    def test_set_eip1559_fees(self):
         with mock.patch.object(
-            EthereumClient, "estimate_fee_eip1159", return_value=(2, 5)
+            EthereumClient, "estimate_fee_eip1559", return_value=(2, 5)
         ):
             tx: TxParams = {"to": Account.create(), "value": 1, "gasPrice": 5}
-            eip_1159_tx = self.ethereum_client.set_eip1159_fees(tx)
+            eip_1559_tx = self.ethereum_client.set_eip1559_fees(tx)
             self.assertIn("gasPrice", tx)  # Provided tx is not modified
-            self.assertNotIn("gasPrice", eip_1159_tx)
-            self.assertEqual(eip_1159_tx["maxPriorityFeePerGas"], 5)
-            self.assertEqual(eip_1159_tx["maxFeePerGas"], 7)
+            self.assertNotIn("gasPrice", eip_1559_tx)
+            self.assertEqual(
+                eip_1559_tx["chainId"], self.ethereum_client.get_network().value
+            )
+            self.assertEqual(eip_1559_tx["maxPriorityFeePerGas"], 5)
+            self.assertEqual(eip_1559_tx["maxFeePerGas"], 7)
 
 
 class TestEthereumClientWithMainnetNode(EthereumTestCaseMixin, TestCase):
@@ -1476,14 +1479,14 @@ class TestEthereumClientWithMainnetNode(EthereumTestCaseMixin, TestCase):
         mainnet_node = just_test_if_mainnet_node()
         cls.ethereum_client = EthereumClient(mainnet_node)
 
-    def test_estimate_fee_eip1159(self):
+    def test_estimate_fee_eip1559(self):
         """
-        EIP1159 is still not supported on Ganache
+        EIP1559 is still not supported on Ganache
         """
         (
             base_fee_per_gas,
             max_priority_fee_per_gas,
-        ) = self.ethereum_client.estimate_fee_eip1159()
+        ) = self.ethereum_client.estimate_fee_eip1559()
         self.assertGreater(base_fee_per_gas, 0)
         self.assertGreater(max_priority_fee_per_gas, 0)
 


### PR DESCRIPTION
- `chainId` is mandatory for eip1559 txs
- Rename `eip1159` -> `eip1559`