### PR TITLE
refactor: replace deprecated pyethereum library

### DIFF
--- a/gnosis/eth/constants.py
+++ b/gnosis/eth/constants.py
@@ -1,4 +1,4 @@
-from ethereum.transactions import secpk1n
+from eth.constants import SECPK1_N
 
 NULL_ADDRESS: str = "0x" + "0" * 40
 SENTINEL_ADDRESS: str = "0x" + "0" * 39 + "1"
@@ -9,9 +9,9 @@ ERC20_721_TRANSFER_TOPIC: str = (
 )
 
 SIGNATURE_R_MIN_VALUE: int = 1
-SIGNATURE_R_MAX_VALUE: int = secpk1n - 1
+SIGNATURE_R_MAX_VALUE: int = SECPK1_N - 1
 SIGNATURE_S_MIN_VALUE: int = 1
-SIGNATURE_S_MAX_VALUE: int = secpk1n // 2
+SIGNATURE_S_MAX_VALUE: int = SECPK1_N // 2
 SIGNATURE_V_MIN_VALUE: int = 27
 SIGNATURE_V_MAX_VALUE: int = 28
 

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -16,11 +16,12 @@ from typing import (
 
 import eth_abi
 import requests
+from eth._utils.address import generate_contract_address
 from eth_abi.exceptions import DecodingError
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import URI, BlockNumber, ChecksumAddress, Hash32, HexStr
-from ethereum.utils import mk_contract_address
+from eth_utils import to_canonical_address, to_checksum_address
 from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
 from web3._utils.abi import map_abi_data
@@ -1447,8 +1448,10 @@ class EthereumClient:
 
                 if not contract_address:
                     contract_address = ChecksumAddress(
-                        Web3.toChecksumAddress(
-                            mk_contract_address(tx["from"], tx["nonce"])
+                        to_checksum_address(
+                            generate_contract_address(
+                                to_canonical_address(tx["from"]), tx["nonce"]
+                            )
                         )
                     )
 

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -16,12 +16,10 @@ from typing import (
 
 import eth_abi
 import requests
-from eth._utils.address import generate_contract_address
 from eth_abi.exceptions import DecodingError
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import URI, BlockNumber, ChecksumAddress, Hash32, HexStr
-from eth_utils import to_canonical_address, to_checksum_address
 from hexbytes import HexBytes
 from web3 import HTTPProvider, Web3
 from web3._utils.abi import map_abi_data
@@ -54,6 +52,8 @@ from web3.types import (
     TxReceipt,
     Wei,
 )
+
+from gnosis.eth.utils import mk_contract_address
 
 from .constants import (
     ERC20_721_TRANSFER_TOPIC,
@@ -1448,11 +1448,7 @@ class EthereumClient:
 
                 if not contract_address:
                     contract_address = ChecksumAddress(
-                        to_checksum_address(
-                            generate_contract_address(
-                                to_canonical_address(tx["from"]), tx["nonce"]
-                            )
-                        )
+                        mk_contract_address(tx["from"], tx["nonce"])
                     )
 
         return EthereumTxSent(tx_hash, tx, contract_address)

--- a/gnosis/eth/utils.py
+++ b/gnosis/eth/utils.py
@@ -1,21 +1,16 @@
-import os
+from secrets import token_bytes
 from typing import Tuple, Union
 
 import eth_abi
-from ethereum import utils
+from eth_keys import keys
 from hexbytes import HexBytes
 from web3 import Web3
 
 
 def get_eth_address_with_key() -> Tuple[str, bytes]:
-    # import secp256k1
-    # private_key = secp256k1.PrivateKey().private_key
-    private_key = Web3.keccak(os.urandom(4096))
-    public_key = Web3.toChecksumAddress(utils.privtoaddr(private_key))
-    # If you want to use secp256k1 to calculate public_key
-    # utils.checksum_encode(utils.sha3(p.pubkey.serialize(compressed=False)[1:])[-20:])
-
-    return public_key, private_key
+    private_key = keys.PrivateKey(token_bytes(32))
+    address = private_key.public_key.to_checksum_address()
+    return address, private_key.to_bytes()
 
 
 def get_eth_address_with_invalid_checksum() -> str:

--- a/gnosis/eth/utils.py
+++ b/gnosis/eth/utils.py
@@ -2,7 +2,9 @@ from secrets import token_bytes
 from typing import Tuple, Union
 
 import eth_abi
+from eth._utils.address import generate_contract_address
 from eth_keys import keys
+from eth_utils import to_canonical_address, to_checksum_address
 from hexbytes import HexBytes
 from web3 import Web3
 
@@ -90,3 +92,9 @@ def compare_byte_code(code_1: bytes, code_2: bytes) -> bool:
                 codes.append(code)
 
         return codes[0] == codes[1]
+
+
+def mk_contract_address(address: Union[str, bytes], nonce: int) -> str:
+    return to_checksum_address(
+        generate_contract_address(to_canonical_address(address), nonce)
+    )

--- a/gnosis/safe/safe_signature.py
+++ b/gnosis/safe/safe_signature.py
@@ -3,10 +3,10 @@ from enum import Enum
 from logging import getLogger
 from typing import List, Union
 
-from eth_abi import encode_single
+from eth_abi import decode_single, encode_single
 from eth_abi.exceptions import DecodingError
 from eth_account.messages import defunct_hash_message
-from ethereum.utils import checksum_encode
+from eth_utils import to_checksum_address
 from hexbytes import HexBytes
 from web3.exceptions import BadFunctionCallOutput
 
@@ -169,8 +169,9 @@ class SafeSignatureContract(SafeSignature):
         :return: Address of contract signing. No further checks to get the owner are needed,
             but it could be a non existing contract
         """
-        contract_address = checksum_encode(self.r)
-        return contract_address
+        return to_checksum_address(
+            decode_single("address", encode_single("uint", self.r))
+        )
 
     @property
     def signature_type(self):
@@ -208,7 +209,9 @@ class SafeSignatureContract(SafeSignature):
 class SafeSignatureApprovedHash(SafeSignature):
     @property
     def owner(self):
-        return checksum_encode(self.r)
+        return to_checksum_address(
+            decode_single("address", encode_single("uint", self.r))
+        )
 
     @property
     def signature_type(self):

--- a/gnosis/safe/signatures.py
+++ b/gnosis/safe/signatures.py
@@ -1,8 +1,7 @@
 from typing import List, Tuple, Union
 
-from ethereum.utils import ecrecover_to_pub
+from eth_keys import keys
 from hexbytes import HexBytes
-from web3 import Web3
 
 
 def signature_split(
@@ -56,6 +55,5 @@ def get_signing_address(signed_hash: Union[bytes, str], v: int, r: int, s: int) 
     :return: checksummed ethereum address, for example `0x568c93675A8dEb121700A6FAdDdfE7DFAb66Ae4A`
     :rtype: str
     """
-    encoded_64_address = ecrecover_to_pub(HexBytes(signed_hash), v, r, s)
-    address_bytes = Web3.keccak(encoded_64_address)[-20:]
-    return Web3.toChecksumAddress(address_bytes)
+    public_key = keys.ecdsa_recover(signed_hash, keys.Signature(vrs=(v - 27, r, s)))
+    return public_key.to_checksum_address()

--- a/gnosis/safe/tests/utils.py
+++ b/gnosis/safe/tests/utils.py
@@ -2,7 +2,7 @@ import os
 import random
 from logging import getLogger
 
-from ethereum.transactions import secpk1n
+from eth.constants import SECPK1_N
 from web3 import Web3
 
 from gnosis.eth.tests.utils import send_tx
@@ -19,7 +19,7 @@ def generate_salt_nonce() -> int:
 def generate_valid_s() -> int:
     while True:
         s = int(os.urandom(30).hex(), 16)
-        if s <= (secpk1n // 2):
+        if s <= (SECPK1_N // 2):
             return s
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ django==3.2.11
 django-filter==21.1
 djangorestframework==3.13.1
 eip712-structs==1.1.0
-ethereum==2.3.2
 hexbytes==0.2.2
 packaging
 psycopg2-binary==2.9.3
+py-evm==0.5.0a3
 requests==2.27.1
 typing-extensions==3.10.0.2
 web3==5.24.0


### PR DESCRIPTION
replace all usages of a [deprecated](https://github.com/ethereum/pyethereum) pyethereum library with alternatives from py-evm, eth-utils, eth-keys
