### PR TITLE
Ignore invalid padding for Safe tx signatures

### DIFF
--- a/gnosis/safe/tests/test_safe_signature.py
+++ b/gnosis/safe/tests/test_safe_signature.py
@@ -55,6 +55,17 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
         self.assertEqual(safe_signature.signature_type, SafeSignatureType.APPROVED_HASH)
         self.assertTrue(str(safe_signature))  # Test __str__
 
+        # Problematic signature found on rinkeby tx-hash 0x10df7fd8b75297af360ae335ca7562be92cafbbd39cc72172e17fcaebccc4f42
+        # Note the ff preceding the address
+        signature = HexBytes(
+            "0x0000000000000000000000ffdc5299b629ef24fdecfbb240c00fc79fabb9cf97000000000000000000000000000000000000000000000000000000000000000001"
+        )
+        # Safe tx hash is not relevant for this case, use the same one
+        safe_signature = SafeSignatureApprovedHash(signature, b"")
+        self.assertEqual(
+            safe_signature.owner, "0xdC5299b629Ef24fDECfBb240C00Fc79FAbB9cf97"
+        )
+
     def test_approved_hash_signature_build(self):
         owner = Account.create().address
         safe_tx_hash = Web3.keccak(text="random")


### PR DESCRIPTION
Padding bytes are ignored by Solidity, but not by Python, so I trim them and replace by null bytes